### PR TITLE
Add Not Supported status code for optional methods

### DIFF
--- a/types.go
+++ b/types.go
@@ -3,8 +3,9 @@ package flexvolume
 type Status string
 
 const (
-	StatusSuccess Status = "Success"
-	StatusFailure Status = "Failure"
+	StatusSuccess Status       = "Success"
+	StatusFailure Status       = "Failure"
+	StatusNotSupported Status  = "Not Supported"
 )
 
 type FlexVolume interface {


### PR DESCRIPTION
Part of the flexvolume plugin interface is optional.
e.g : Some plugins don't need to attach/detach (because it's a network drive fs or a tmpfs for instance)

In those cases the right thing to do (at least for k8s 1.4.x) is to return "Not Supported"